### PR TITLE
Changed format of ChangeLog to follow CPAN::Changes::Spec

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,21 +1,28 @@
-2017-08-24      Ben Bullock <bkb@cpan.org>              (0.4)
+Revision history for Perl module Net::IPv6Addr
+
+0.5 2017-08-??      Ben Bullock <bkb@cpan.org>
+
+	* Changed format of ChangeLog to follow CPAN::Changes::Spec,
+	  which means it will be displayed nicely by MetaCPAN.
+
+0.4 2017-08-24      Ben Bullock <bkb@cpan.org>
 
 	* Add contributors and licence information
 	* Add documentation
 	* Remove RFCs from distro
 
-2017-08-24      Ben Bullock <bkb@cpan.org>              (0.3)
+0.3 2017-08-24      Ben Bullock <bkb@cpan.org>
 
 	* Add meta files to distribution
 	* in_network altered
 	* Documentation updates
 
-2002-05-03	Tony Monroe <tmonroe+perl@nog.net>	(0.2)
+0.2 2002-08-06	Tony Monroe <tmonroe+perl@nog.net>
 
 	* Many patches from Jyrki Soini <jyrki.soini@sonera.com>,
 	  fixing bugs and adding features!
 
-2001-07-20	Tony Monroe <tmonroe+perl@nog.net>	(0.1)
+0.1 2001-07-21	Tony Monroe <tmonroe+perl@nog.net>
 
 	* Based on Net::IPv4Addr version 0.10.
 		Author: Francis J. Lacoste <francis.lacoste@iNsu.COM>
@@ -25,3 +32,4 @@
 	* Takes any input or output format described by RFC1884 or RFC1924.
 
 	* Automatically generates those pesky IP6.INT. strings (RFC1886).
+

--- a/lib/Net/IPv6Addr.pm
+++ b/lib/Net/IPv6Addr.pm
@@ -45,7 +45,7 @@ The public interface of this module is rather small.
 @EXPORT = qw();
 @EXPORT_OK = qw();
 
-$VERSION = '0.4';
+$VERSION = '0.5';
 
 # We get these formats from rfc1884:
 #


### PR DESCRIPTION
Hi Ben,

I looked at the release page for this on MetaCPAN, and noticed the changes weren't displayed.

This PR reformats ChangeLog to follow the *de facto* standard format for Changes, one benefit of which is that MetaCPAN will display the changes in the most recent list when you look at the release page.

Cheers,
Neil
